### PR TITLE
fix aspect ratio of gifs

### DIFF
--- a/covfefe-art.js
+++ b/covfefe-art.js
@@ -13,15 +13,15 @@ childProcess.fork(path.join(__dirname, 'music.js'));
 function updateFrame(frame, cb) {
 	var covfefe = [];
 	var skipped = false;
-	for (var y = 0; y < frame.height; y += 2) {
-		for (var x = 0; x < frame.width; x += 1) {
+	for (var y = 0; y < frame.height; y += 4) {
+		for (var x = 0; x < frame.width; x += 2) {
 			var offset = ((y * frame.width) + x) * 4;
 			if (frame.data[offset + 3] === 0) {
 				skipped = true;
 			} else {
 				if (skipped) {
 					skipped = false;
-					covfefe.push('\x1b[' + (y / 2 + 1) + ';' + (x + 1) + 'H');
+					covfefe.push('\x1b[' + (y / 4 + 1) + ';' + (x / 2 + 1) + 'H');
 				}
 
 				switch (supportsColor.level) {

--- a/covfefe-art.js
+++ b/covfefe-art.js
@@ -14,14 +14,14 @@ function updateFrame(frame, cb) {
 	var covfefe = [];
 	var skipped = false;
 	for (var y = 0; y < frame.height; y += 2) {
-		for (var x = 0; x < frame.width; x += 2) {
+		for (var x = 0; x < frame.width; x += 1) {
 			var offset = ((y * frame.width) + x) * 4;
 			if (frame.data[offset + 3] === 0) {
 				skipped = true;
 			} else {
 				if (skipped) {
 					skipped = false;
-					covfefe.push('\x1b[' + (y / 2 + 1) + ';' + (x / 2 + 1) + 'H');
+					covfefe.push('\x1b[' + (y / 2 + 1) + ';' + (x + 1) + 'H');
 				}
 
 				switch (supportsColor.level) {


### PR DESCRIPTION
cc @Qix- 

I was mostly guessing, but this seems to fix the aspect ratio issue I was seeing before.


| before | after | 
|---|---|
| ![image](https://cloud.githubusercontent.com/assets/39191/26745314/cc3e5346-479e-11e7-898f-845947a1ade6.png) | ![image](https://cloud.githubusercontent.com/assets/39191/26745302/bb0a8fe0-479e-11e7-9d8f-14e8c8c8cc62.png) | 


As a downside, it appears performance is slightly worse now. Presumably the width/height could be halved from this and it'd be pretty nice.
